### PR TITLE
Remove horizontal separator from footer

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, memo, PropsWithChildren, useEffect } from "react";
 import { useLayoutContext } from "./context";
 import { cn } from "@/utils";
-import { Separator } from "@/index";
 
 export function LayoutFooter({
   children,
@@ -23,7 +22,6 @@ export function LayoutFooter({
         className,
       )}
     >
-      <Separator orientation="horizontal" className="bg-spacer" />
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- Removes the horizontal separator line from the layout footer component  
- Cleans up unused Separator import

## Test plan
- Verify footer displays correctly without the separator line
- Check that the layout remains visually consistent

🤖 Generated with [Claude Code](https://claude.ai/code)