### PR TITLE
fix: render null for user with no points

### DIFF
--- a/src/components/modules/create-account/account-search-result.stories.tsx
+++ b/src/components/modules/create-account/account-search-result.stories.tsx
@@ -36,6 +36,28 @@ export const ExistingUser: Story = {
   },
 };
 
+export const ExistingUserWithNoPoints: Story = {
+  args: {
+    result: {
+      id: "existing-shinobi",
+      type: "existing",
+      username: "shinobi",
+      points: 0,
+      lastOnline: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000), // 2 days ago
+    },
+  },
+};
+
+export const NewUser: Story = {
+  args: {
+    result: {
+      id: "create-new-shin",
+      type: "create-new",
+      username: "shin",
+    },
+  },
+};
+
 export const MultipleResult: Story = {
   render: function MultipleResult() {
     const mockResults = [
@@ -65,15 +87,5 @@ export const MultipleResult: Story = {
         ))}
       </div>
     );
-  },
-};
-
-export const NewUser: Story = {
-  args: {
-    result: {
-      id: "create-new-shin",
-      type: "create-new",
-      username: "shin",
-    },
   },
 };

--- a/src/components/modules/create-account/account-search-result.tsx
+++ b/src/components/modules/create-account/account-search-result.tsx
@@ -117,7 +117,7 @@ export const AccountSearchResultItem = React.forwardRef<
       <div className="flex flex-row items-center justify-between gap-1 flex-1">
         <p className="text-sm font-normal px-0.5 truncate">{result.username}</p>
 
-        {result.points && (
+        {result.points ? (
           <div className="flex items-start gap-2.5 p-2">
             <div className="flex items-center justify-center gap-0.5 p-1 bg-background-300 rounded text-foreground-100">
               <SparklesIcon
@@ -127,12 +127,12 @@ export const AccountSearchResultItem = React.forwardRef<
               />
               <div className="flex items-center gap-1">
                 <p className="text-xs font-medium text-foreground-100">
-                  {result.points.toLocaleString()}
+                  {result.points?.toLocaleString() || 0}
                 </p>
               </div>
             </div>
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
Fixed a bug where user with 0 points renders "0" instead of null. This is due to wrong ternary usage for conditional rendering

old:
<img width="864" height="182" alt="CleanShot 2025-09-26 at 02 12 21@2x" src="https://github.com/user-attachments/assets/73fa6318-0625-4774-85b4-1b35c16293ad" />


fix:
<img width="826" height="162" alt="CleanShot 2025-09-26 at 02 11 35@2x" src="https://github.com/user-attachments/assets/70a0d66a-b972-45ca-b467-03e7e2b9f17a" />
