### PR TITLE
Update presets dependency to commit 90a5fe0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "test:ci": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@cartridge/presets": "github:cartridge-gg/presets#e6a5022",
+    "@cartridge/presets": "github:cartridge-gg/presets#90a5fe0",
     "@radix-ui/react-accordion": "^1.2.6",
     "@radix-ui/react-alert-dialog": "^1.1.9",
     "@radix-ui/react-aspect-ratio": "^1.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@cartridge/presets':
-        specifier: github:cartridge-gg/presets#e6a5022
-        version: https://codeload.github.com/cartridge-gg/presets/tar.gz/e6a5022
+        specifier: github:cartridge-gg/presets#90a5fe0
+        version: https://codeload.github.com/cartridge-gg/presets/tar.gz/90a5fe0
       '@radix-ui/react-accordion':
         specifier: ^1.2.6
         version: 1.2.10(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -672,8 +672,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cartridge/presets@https://codeload.github.com/cartridge-gg/presets/tar.gz/e6a5022':
-    resolution: {tarball: https://codeload.github.com/cartridge-gg/presets/tar.gz/e6a5022}
+  '@cartridge/presets@https://codeload.github.com/cartridge-gg/presets/tar.gz/90a5fe0':
+    resolution: {tarball: https://codeload.github.com/cartridge-gg/presets/tar.gz/90a5fe0}
     version: 0.0.1
 
   '@cspotcode/source-map-support@0.8.1':
@@ -6732,7 +6732,7 @@ snapshots:
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
 
-  '@cartridge/presets@https://codeload.github.com/cartridge-gg/presets/tar.gz/e6a5022':
+  '@cartridge/presets@https://codeload.github.com/cartridge-gg/presets/tar.gz/90a5fe0':
     dependencies:
       '@starknet-io/types-js': 0.7.7
 


### PR DESCRIPTION
## Summary
- Updated `@cartridge/presets` dependency from commit `e6a5022` to `90a5fe0`
- Uses the latest release commit from the presets repository
- Ensures build runs successfully with all type declarations available

## Changes Made
- Updated `package.json` to reference presets commit `90a5fe0`
- Updated `pnpm-lock.yaml` with new dependency resolution

## Test plan
- [x] Installed dependencies with `pnpm install` - successful
- [x] Ran build with `pnpm build` - successful  
- [x] Verified all type declarations are available
- [ ] Test in consuming applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update @cartridge/presets from e6a5022 to 90a5fe0 and refresh pnpm lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b70004e5608d64d84902a91f8a2f37c6d43ee41d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->