### PR TITLE
fix: include vercel.json in release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,13 @@ jobs:
           # Create a fresh release branch from main
           git checkout -B release-temp
 
-          # Keep only dist/, storybook-static/, and package.json, remove everything else
-          git ls-files | grep -v "^dist/" | grep -v "^storybook-static/" | grep -v "^package.json" | xargs git rm -f
+          # Keep only dist/, storybook-static/, vercel.json, and package.json, remove everything else
+          git ls-files | grep -v "^dist/" | grep -v "^storybook-static/" | grep -v "^vercel.json" | grep -v "^package.json" | xargs git rm -f
 
           # Make sure all built files are included
           git add -f dist/
           git add -f storybook-static/
+          git add -f vercel.json
           git add package.json
 
           # Commit changes


### PR DESCRIPTION
## Problem
The release workflow was excluding `vercel.json` from the release branch (commit `e70ccfb`), causing Vercel deployments to fail.

**What the release branch had:**
- ✅ `dist/`
- ✅ `storybook-static/`
- ✅ `package.json`
- ❌ `vercel.json` (MISSING!)

Without `vercel.json`, Vercel uses its default/configured build command:
```bash
turbo run build:deps && pnpm storybook:build
```

This fails because `.storybook/` doesn't exist on the release branch.

## Root Cause
Line 38 in `release.yml`:
```yaml
git ls-files | grep -v "^dist/" | grep -v "^storybook-static/" | grep -v "^package.json" | xargs git rm -f
```

This removes **everything** except the three listed items. Since `vercel.json` wasn't in the list, it was deleted.

## Solution
Updated the workflow to keep `vercel.json` on the release branch:
```yaml
git ls-files | grep -v "^dist/" | grep -v "^storybook-static/" | grep -v "^vercel.json" | grep -v "^package.json" | xargs git rm -f
```

And explicitly add it:
```yaml
git add -f vercel.json
```

## After This Fix
Release branch will contain:
- ✅ `dist/` (library artifacts)
- ✅ `storybook-static/` (pre-built storybook)
- ✅ `vercel.json` (deployment config)
- ✅ `package.json` (metadata)

Vercel will read `vercel.json`, detect `storybook-static/` exists, and skip the build.

## Related
- Follow-up to #117 and #118
- Fixes deployment issue in commit `e70ccfb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)