### PR TITLE
Fix formatNumber to handle BigInt values

### DIFF
--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,5 +1,13 @@
-export const formatNumber = (num: number | string): string => {
-    const numericValue = typeof num === 'string' ? parseFloat(num) : num;
+export const formatNumber = (num: number | string | bigint): string => {
+    // Handle BigInt by converting to number
+    let numericValue: number;
+    if (typeof num === 'bigint') {
+        numericValue = Number(num);
+    } else if (typeof num === 'string') {
+        numericValue = parseFloat(num);
+    } else {
+        numericValue = num;
+    }
 
     if (isNaN(numericValue)) {
         return '0';


### PR DESCRIPTION
## Summary
- Add support for `bigint` type in `formatNumber` function
- Fixes "Cannot convert a BigInt value to a number" error

## Changes Made
- Updated `formatNumber` signature to accept `number | string | bigint`
- Added explicit BigInt to Number conversion before `isNaN()` check
- Maintains backward compatibility with existing number and string types

## Problem
The `formatNumber` function was failing when BigInt values were passed to components like `CollectiblePreview`. The error occurred because `isNaN()` cannot work with BigInt values directly, throwing:
```
TypeError: Cannot convert a BigInt value to a number
```

## Solution
The function now checks the type of the input and converts BigInt to Number explicitly:
```typescript
if (typeof num === 'bigint') {
    numericValue = Number(num);
}
```

## Test plan
- [x] Function accepts bigint values without errors
- [x] Existing behavior for number and string inputs unchanged
- [x] BigInt values are properly formatted with locale-specific formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extend `formatNumber` to accept `bigint` and safely convert it to a number before formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2003184d5b7cb81ae8ec4311fd28ec10fd1b83c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->