### PR TITLE
fix: change header padding to 12px

### DIFF
--- a/src/components/layout/header.stories.tsx
+++ b/src/components/layout/header.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { EthereumIcon, TransferIcon } from "@/index";
+import { UIProvider } from "@/context";
 import { LayoutHeader } from "./index";
 
 const meta: Meta<typeof LayoutHeader> = {
@@ -149,6 +150,31 @@ export const WithCloseButton: Story = {
   args: {
     onClose: () => {},
   },
+};
+
+export const WithConnectedUser: Story = {
+  args: {
+    onOpenStarterPack: null,
+    onBack: () => {},
+  },
+  decorators: [
+    (Story) => {
+      // Mock the useUI hook to provide connected user state
+      const mockUIContext = {
+        account: {
+          username: "player.stark",
+          address: "0x1234567890abcdef1234567890abcdef12345678",
+        },
+        chainId: "0x534e5f4d41494e", // Starknet Mainnet
+      };
+
+      return (
+        <UIProvider value={mockUIContext}>
+          <Story />
+        </UIProvider>
+      );
+    },
+  ],
 };
 
 export const ReactiveThemeChanges: Story = {

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -103,19 +103,17 @@ export function LayoutHeader({
         }
       })()}
 
-      <div className="flex items-center justify-between absolute top-0 left-0 right-0 h-16 p-2 z-50">
-        <div>
-          {onBack ? (
-            <BackButton onClick={onBack} />
-          ) : shouldShowCloseButton ? (
-            <CloseButton
-              onClose={() => {
-                if (onClose) onClose();
-                if (closeModal) closeModal();
-              }}
-            />
-          ) : null}
-        </div>
+      <div className="flex items-center justify-between absolute top-0 left-0 right-0 h-16 p-3 z-50">
+        {onBack ? (
+          <BackButton onClick={onBack} />
+        ) : shouldShowCloseButton ? (
+          <CloseButton
+            onClose={() => {
+              if (onClose) onClose();
+              if (closeModal) closeModal();
+            }}
+          />
+        ) : null}
 
         <div className="flex items-center gap-2">
           {!!chainId &&

--- a/src/utils/api/cartridge/generated.ts
+++ b/src/utils/api/cartridge/generated.ts
@@ -3403,6 +3403,7 @@ export type Query = {
   price: Array<Price>;
   priceByAddresses: Array<Price>;
   pricePeriodByAddresses: Array<Price>;
+  searchAccounts: Array<Account>;
   session?: Maybe<Session>;
   sessions?: Maybe<SessionConnection>;
   starterpack?: Maybe<StarterpackDetails>;
@@ -3656,6 +3657,12 @@ export type QueryPricePeriodByAddressesArgs = {
   addresses: Array<Scalars['String']>;
   end: Scalars['Int'];
   start: Scalars['Int'];
+};
+
+
+export type QuerySearchAccountsArgs = {
+  limit?: InputMaybe<Scalars['Int']>;
+  query: Scalars['String'];
 };
 
 


### PR DESCRIPTION
This pull request updates the `LayoutHeader` component and its Storybook stories to better support connected user scenarios and improves layout spacing. The main changes include adding a new story that mocks a connected user state via context, updating the component to use more consistent padding, and minor cleanups for improved clarity.

**Storybook improvements:**

* Added a new `WithConnectedUser` story to `header.stories.tsx` that uses `UIProvider` to mock a connected user and chain context, enabling testing of header behavior with a connected account. [[1]](diffhunk://#diff-99aa5be70d306449f57bdc8d73ae9af661506341684ff2fa67952abad9fb93e6R155-R179) [[2]](diffhunk://#diff-99aa5be70d306449f57bdc8d73ae9af661506341684ff2fa67952abad9fb93e6R4)

**Layout and style adjustments:**

* Increased horizontal padding in the header container from `p-2` to `p-3` for better spacing.
* Removed an unnecessary wrapper `<div>` around the back/close button logic for a cleaner DOM structure.

## Storybook
- https://ui-git-fix-header-padding.preview.cartridge.gg/?path=/story/layout-header--with-connected-user